### PR TITLE
Vectorized cvar and csd

### DIFF
--- a/R/vec-cumulative-functions.R
+++ b/R/vec-cumulative-functions.R
@@ -19,13 +19,21 @@
 #' cvar(x)
 #'
 #' @return
-#' A numeric vector
+#' A numeric vector. Note: The first entry will always be
+#' NaN.
 #'
 #' @export
 #'
 
 cvar <- function(.x) {
-  sapply(seq_along(.x), function(k, z) stats::var(z[1:k]), z = .x)
+  n <- length(.x)
+  csumx <- base::cumsum(.x)
+  cmeanx <- cmean(.x)
+
+  p1 <- base::cumsum(.x^2)
+  p2 <- -2 * cmeanx * csumx
+  p3 <- (1:n) * cmeanx^2
+  (p1 + p2 + p3) / ((1:n) - 1)
 }
 
 #' Cumulative Skewness
@@ -112,13 +120,14 @@ ckurtosis <- function(.x) {
 #' csd(x)
 #'
 #' @return
-#' A numeric vector
+#' A numeric vector. Note: The first entry will always be
+#' NaN.
 #'
 #' @export
 #'
 
 csd <- function(.x) {
-  sapply(seq_along(.x), function(k, z) stats::sd(z[1:k]), z = .x)
+  sqrt(cvar(.x))
 }
 
 #' Cumulative Median

--- a/TidyDensity.Rproj
+++ b/TidyDensity.Rproj
@@ -6,7 +6,7 @@ AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
 UseSpacesForTab: Yes
-NumSpacesForTab: 4
+NumSpacesForTab: 2
 Encoding: UTF-8
 
 RnwWeave: Sweave


### PR DESCRIPTION
This PR addresses both #372 #373, given that `csd` is just `sqrt()` of `cvar()`